### PR TITLE
Enable zfor vanity

### DIFF
--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -148,23 +148,7 @@ Public Class frmVanity
     Private Sub txtFind1_TextChanged(sender As Object, e As EventArgs) Handles txtFind1.TextChanged
         Dim Index As Integer = txtFind1.SelectionStart
         Dim result As String = txtFind1.Text
-        If result.Length < 4 Then
-            Do
-                result &= "@"
-                If result.Length = 4 Then Exit Do
-            Loop
-        End If
-        Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
-        result = ""
-        For t As Integer = 0 To 3
-            If Not chars.Contains(txt(t)) Then
-                txt(t) = CChar("@")
-
-            End If
-            result &= txt(t)
-        Next
-        txtFind1.Text = result
+        txtFind1.Text = sanitizeTxt(result, 4)
         txtFind1.Select(Index, 0)
         If Index = 4 Then txtFind2.Focus()
 
@@ -173,22 +157,7 @@ Public Class frmVanity
     Private Sub txtFind2_TextChanged(sender As Object, e As EventArgs) Handles txtFind2.TextChanged
         Dim Index As Integer = txtFind2.SelectionStart
         Dim result As String = txtFind2.Text
-        If result.Length < 4 Then
-            Do
-                result &= "@"
-                If result.Length = 4 Then Exit Do
-            Loop
-        End If
-        Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
-        result = ""
-        For t As Integer = 0 To 3
-            If Not chars.Contains(txt(t)) Then
-                txt(t) = CChar("@")
-            End If
-            result &= txt(t)
-        Next
-        txtFind2.Text = result
+        txtFind2.Text = sanitizeTxt(result, 4)
         txtFind2.Select(Index, 0)
         If Index = 4 Then txtFind3.Focus()
         '  If Index = 0 Then txtFind1.Focus()
@@ -204,23 +173,7 @@ Public Class frmVanity
     Private Sub txtFind3_TextChanged(sender As Object, e As EventArgs) Handles txtFind3.TextChanged
         Dim Index As Integer = txtFind3.SelectionStart
         Dim result As String = txtFind3.Text
-        If result.Length < 4 Then
-            Do
-                result &= "@"
-                If result.Length = 4 Then Exit Do
-            Loop
-        End If
-        Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
-        result = ""
-        For t As Integer = 0 To 3
-            If Not chars.Contains(txt(t)) Then
-                txt(t) = CChar("@")
-
-            End If
-            result &= txt(t)
-        Next
-        txtFind3.Text = result
+        txtFind3.Text = sanitizeTxt(result, 4)
         txtFind3.Select(Index, 0)
         If Index = 4 Then txtFind4.Focus()
         '  If Index = 0 Then txtFind2.Focus()
@@ -236,23 +189,7 @@ Public Class frmVanity
     Private Sub txtFind4_TextChanged(sender As Object, e As EventArgs) Handles txtFind4.TextChanged
         Dim Index As Integer = txtFind4.SelectionStart
         Dim result As String = txtFind4.Text
-        If result.Length < 5 Then
-            Do
-                result &= "@"
-                If result.Length = 5 Then Exit Do
-            Loop
-        End If
-        Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
-        result = ""
-        For t As Integer = 0 To 4
-            If Not chars.Contains(txt(t)) Then
-                txt(t) = CChar("@")
-
-            End If
-            result &= txt(t)
-        Next
-        txtFind4.Text = result
+        txtFind4.Text = sanitizeTxt(result, 5)
         txtFind4.Select(Index, 0)
         '  If Index = 0 Then txtFind3.Focus()
 
@@ -264,6 +201,22 @@ Public Class frmVanity
             End If
         End If
     End Sub
+
+    Private Function sanitizeTxt(result As String, allowedLength As Integer) As String
+        While result.Length < allowedLength
+            result &= "@"
+        End While
+        Dim txt() As Char = UCase(result).ToCharArray
+        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
+        result = ""
+        For t As Integer = 0 To (allowedLength - 1)
+            If Not chars.Contains(txt(t)) Then
+                txt(t) = CChar("@")
+            End If
+            result &= txt(t)
+        Next
+        Return result
+    End Function
 
     Private Sub SaveAsTextfileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles SaveAsTextfileToolStripMenuItem.Click
         Dim sfd As New SaveFileDialog

--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -77,7 +77,7 @@ Public Class frmVanity
         ' Dim Crv As New Curve
 
         Dim chars() As String = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-         "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "X",
+         "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
          "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
         Dim TotalChars As Integer = UBound(chars)
         Do
@@ -155,7 +155,7 @@ Public Class frmVanity
             Loop
         End If
         Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYX23456789@"
+        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
         result = ""
         For t As Integer = 0 To 3
             If Not chars.Contains(txt(t)) Then
@@ -180,7 +180,7 @@ Public Class frmVanity
             Loop
         End If
         Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYX23456789@"
+        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
         result = ""
         For t As Integer = 0 To 3
             If Not chars.Contains(txt(t)) Then
@@ -211,7 +211,7 @@ Public Class frmVanity
             Loop
         End If
         Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYX23456789@"
+        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
         result = ""
         For t As Integer = 0 To 3
             If Not chars.Contains(txt(t)) Then
@@ -243,7 +243,7 @@ Public Class frmVanity
             Loop
         End If
         Dim txt() As Char = UCase(result).ToCharArray
-        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYX23456789@"
+        Dim chars As String = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789@"
         result = ""
         For t As Integer = 0 To 4
             If Not chars.Contains(txt(t)) Then
@@ -315,7 +315,7 @@ Public Class frmVanity
 
 
                                               Dim chars() As String = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-         "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "X",
+         "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
          "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
                                               Dim TotalChars As Integer = UBound(chars)
 

--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -65,6 +65,11 @@ Public Class frmVanity
                 nrThreads.Value = Environment.ProcessorCount - 1
         End Select
     End Sub
+
+    Private Sub frmVanity_FormClosing(sender As System.Object, e As System.Windows.Forms.FormClosingEventArgs) Handles MyBase.FormClosing
+        running = False
+    End Sub
+
     Private Sub VanityGeneration()
         Dim AccountAddress As String
         Dim KeySeed As String = ""

--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -150,8 +150,10 @@ Public Class frmVanity
         Dim result As String = txtFind1.Text
         txtFind1.Text = sanitizeTxt(result, 4)
         txtFind1.Select(Index, 0)
-        If Index = 4 Then txtFind2.Focus()
-
+        If Index = 4 Then
+            txtFind2.Focus()
+            txtFind2.Select(0, 0)
+        End If
     End Sub
 
     Private Sub txtFind2_TextChanged(sender As Object, e As EventArgs) Handles txtFind2.TextChanged
@@ -159,8 +161,10 @@ Public Class frmVanity
         Dim result As String = txtFind2.Text
         txtFind2.Text = sanitizeTxt(result, 4)
         txtFind2.Select(Index, 0)
-        If Index = 4 Then txtFind3.Focus()
-        '  If Index = 0 Then txtFind1.Focus()
+        If Index = 4 Then
+            txtFind3.Focus()
+            txtFind3.Select(0, 0)
+        End If
     End Sub
     Private Sub txtFind2_TextKeyDown(sender As Object, e As KeyEventArgs) Handles txtFind2.KeyDown
         If txtFind2.SelectionStart = 0 Then
@@ -175,8 +179,10 @@ Public Class frmVanity
         Dim result As String = txtFind3.Text
         txtFind3.Text = sanitizeTxt(result, 4)
         txtFind3.Select(Index, 0)
-        If Index = 4 Then txtFind4.Focus()
-        '  If Index = 0 Then txtFind2.Focus()
+        If Index = 4 Then
+            txtFind4.Focus()
+            txtFind4.Select(0, 0)
+        End If
     End Sub
     Private Sub txtFind3_TextKeyDown(sender As Object, e As KeyEventArgs) Handles txtFind3.KeyDown
         If txtFind3.SelectionStart = 0 Then
@@ -191,8 +197,6 @@ Public Class frmVanity
         Dim result As String = txtFind4.Text
         txtFind4.Text = sanitizeTxt(result, 5)
         txtFind4.Select(Index, 0)
-        '  If Index = 0 Then txtFind3.Focus()
-
     End Sub
     Private Sub txtFind4_TextKeyDown(sender As Object, e As KeyEventArgs) Handles txtFind4.KeyDown
         If txtFind4.SelectionStart = 0 Then


### PR DESCRIPTION
The new address generation feature looks nice but a little typo prevents the user to generate addresses containing 'Z'. Commit e0c8e1f fix this issue.

Additional this pull requests offers:
 - remove of some code duplication (commit f492576)
 - selection reset on field transition (commit 5b316ef)
Just nice to have. It feels more consistent if the cursor always jumps to the first character of the next field instead of depending on it's last selection.
 - thread stop on form closing (commit 58f5ec0). Otherwise if form is close while generation is running it will continue in background until either address is found or QBundle itself is closed.