### PR TITLE
Running QBundle wallet prevents system shutdown.

### DIFF
--- a/QBundle/frmMain.vb
+++ b/QBundle/frmMain.vb
@@ -208,7 +208,8 @@
         Try
             If Running And Not Q.Service.IsServiceRunning Then
                 e.Cancel = True
-                If MsgBox("Do you want to shutdown the wallet?", MsgBoxStyle.YesNo, "Exit") = MsgBoxResult.No Then
+                If e.CloseReason = CloseReason.UserClosing And
+                    MsgBox("Do you want to shutdown the wallet?", MsgBoxStyle.YesNo, "Exit") = MsgBoxResult.No Then
                     Exit Sub
                 End If
                 ShutdownWallet.Interval = 100


### PR DESCRIPTION
If QBundle wallet is running and user tries to shutdown Windows the wallet will it's close confirmation dialog. This will block Windows shutdown and (at least on Windows 7) show a message indicating it wait for some applications to stop.

Now for the best part: Windows information about a still running program hinders the user to stop this program. :D (until some timeout expire and windows just kill every program left)

So this pull request recommends as solution for this (somewhat rare) problem to just show confirmation dialog if user action is the reason to close QBundle. Otherwise just stop the wallet.