### PR TITLE
Boost vanity generation

### DIFF
--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -80,11 +80,11 @@ Public Class frmVanity
          "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "X",
          "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
         Dim TotalChars As Integer = UBound(chars)
+        Randomize()
         Do
             If running = False Then Exit Do
             KeySeed = ""
             For x = 1 To NrofChars
-                Randomize()
                 KeySeed &= chars(Int(Rnd() * TotalChars))
             Next
             cSHA256 = SHA256Managed.Create()

--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -1,5 +1,6 @@
 ﻿Imports System.Numerics
 Imports System.Security.Cryptography
+Imports System.Text
 Imports System.Text.RegularExpressions
 Imports System.Threading
 
@@ -68,7 +69,7 @@ Public Class frmVanity
     End Sub
     Private Sub VanityGeneration()
         Dim AccountAddress As String
-        Dim KeySeed As String = ""
+        Dim KeySeed As New StringBuilder(NrofChars)
         Dim PrivateKey As Byte()
         Dim PublicKey As Byte()
         Dim PublicKeyHash As Byte()
@@ -84,9 +85,9 @@ Public Class frmVanity
         Dim TotalChars As Integer = UBound(chars)
         Do
             If running = False Then Exit Do
-            KeySeed = ""
+            KeySeed.Clear()
             For x = 1 To NrofChars
-                KeySeed &= chars(rand.Next(TotalChars))
+                KeySeed.Append(chars(rand.Next(TotalChars)))
             Next
             cSHA256 = SHA256Managed.Create()
             PrivateKey = cSHA256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(KeySeed))
@@ -100,7 +101,7 @@ Public Class frmVanity
             End SyncLock
             If Regex.IsMatch(AccountAddress, AddressToFind) Then
                 If ValidateAddress(AccountAddress) Then
-                    Found(AccountAddress, KeySeed)
+                    Found(AccountAddress, KeySeed.ToString())
                     Exit Sub
                 End If
             End If

--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -73,8 +73,9 @@ Public Class frmVanity
         Dim PrivateKey As Byte()
         Dim PublicKey As Byte()
         Dim PublicKeyHash As Byte()
-        Dim cSHA256 As SHA256
+        Dim cSHA256 As SHA256 = SHA256Managed.Create()
         Dim rand As New Random(mainRand.Next())
+        Dim toFindPattern As Regex = New Regex(AddressToFind)
         Dim b As Byte()
         Dim x As Integer
         ' Dim Crv As New Curve
@@ -89,7 +90,6 @@ Public Class frmVanity
             For x = 1 To NrofChars
                 KeySeed.Append(chars(rand.Next(TotalChars)))
             Next
-            cSHA256 = SHA256Managed.Create()
             PrivateKey = cSHA256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(KeySeed))
             PublicKey = Curve25519.GetPublicKey(PrivateKey)
             PublicKeyHash = cSHA256.ComputeHash(PublicKey)
@@ -99,7 +99,7 @@ Public Class frmVanity
             SyncLock LockObj
                 Tested += 1
             End SyncLock
-            If Regex.IsMatch(AccountAddress, AddressToFind) Then
+            If toFindPattern.IsMatch(AccountAddress) Then
                 If ValidateAddress(AccountAddress) Then
                     Found(AccountAddress, KeySeed.ToString())
                     Exit Sub

--- a/QBundle/frmVanity.vb
+++ b/QBundle/frmVanity.vb
@@ -12,6 +12,7 @@ Public Class frmVanity
     Private LockObj As Object
     Private counter As Integer
     Private lastval As Integer
+    Private mainRand As New Random
     Private Sub Button2_Click(sender As Object, e As EventArgs) Handles btnSave.Click
         Me.cmSave.Show(Me.btnSave, Me.btnSave.PointToClient(Cursor.Position))
     End Sub
@@ -72,6 +73,7 @@ Public Class frmVanity
         Dim PublicKey As Byte()
         Dim PublicKeyHash As Byte()
         Dim cSHA256 As SHA256
+        Dim rand As New Random(mainRand.Next())
         Dim b As Byte()
         Dim x As Integer
         ' Dim Crv As New Curve
@@ -80,12 +82,11 @@ Public Class frmVanity
          "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "X",
          "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"}
         Dim TotalChars As Integer = UBound(chars)
-        Randomize()
         Do
             If running = False Then Exit Do
             KeySeed = ""
             For x = 1 To NrofChars
-                KeySeed &= chars(Int(Rnd() * TotalChars))
+                KeySeed &= chars(rand.Next(TotalChars))
             Next
             cSHA256 = SHA256Managed.Create()
             PrivateKey = cSHA256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(KeySeed))


### PR DESCRIPTION
This pull request offers some changes to improve performance of the new Vanity Address Generator tool.
All commits probably work on there own (only tested all in commit order) so you can select which you want to merge.

Commit 2b685d6:
There is no need to initialize the random number generator before every usage. This change yields a significant performance boost.

Commit 9a1128b:
Since this project uses .NET anyways its even better (**and faster**) to use .NETs Random class instead of `Rnd()`.
I gave every thread there own Random object because they are not thread safe and synchronization may again bad for performance.
The reason for the extra "main" random object: if the thread random objects are not explicit seeded they use current time as seed and since all threads start at (nearly) same time the risk exists that two randoms are initialized with the same value therefor generating the same addresses.

Commit a8a1b5d:
This one improves generation performance of the passphrase by using a StringBuilder. Also a notable performance boost.

Commit f549656:
Last one just removed some unnecessary object creations. Probably least performance boost of all commits.