### PR TITLE
Pop-Off if wallet is not listening on localhost.

### DIFF
--- a/QBundle/frmPopOff.vb
+++ b/QBundle/frmPopOff.vb
@@ -45,13 +45,20 @@
                 frmMain.StartWallet(True)
             Case 3 'we have wallet in debug mode
                 'now trying to popoff
+                Dim s() As String = Split(Q.settings.ListenIf, ";")
+                Dim url As String = Nothing
+                If s(0) = "0.0.0.0" Then
+                    url = "http://127.0.0.1:" & s(1)
+                Else
+                    url = "http://" & s(0) & ":" & s(1)
+                End If
 
                 lblInfo.Refresh()
                 Dim http As New clsHttp
                 lblInfo.Text = "Clearing unconfirmed transactions."
-                Dim result As String = http.GetUrl("http://localhost:8125/burst?requestType=clearUnconfirmedTransactions")
+                Dim result As String = http.GetUrl(url & "/burst?requestType=clearUnconfirmedTransactions")
                 lblInfo.Text = "Popping off blocks"
-                result = http.GetUrl("http://localhost:8125/burst?requestType=popOff&height=&numBlocks=" & nrBlocks.Value.ToString)
+                result = http.GetUrl(url & "/burst?requestType=popOff&height=&numBlocks=" & nrBlocks.Value.ToString)
 
                 wStep = 4
                 lblInfo.Text = "Stopping wallet."

--- a/QBundle/frmPopOff.vb
+++ b/QBundle/frmPopOff.vb
@@ -17,13 +17,14 @@
 
             If frmMain.Running = True Then
                 WasRunning = True
+                frmMain.StopWallet()
             Else
                 wStep = 1
+                WasRunning = False
             End If
             nrBlocks.Enabled = False
             btnStart.Enabled = False
 
-            frmMain.StopWallet()
             WaitTimer = New Timer
             WaitTimer.Interval = 500
             WaitTimer.Enabled = True
@@ -39,9 +40,9 @@
             Case 0
                 If frmMain.Running = False Then wStep = 1
             Case 1
+                wStep = 2
                 lblInfo.Text = "Starting wallet in debug mode"
                 frmMain.StartWallet(True)
-                wStep = 2
             Case 3 'we have wallet in debug mode
                 'now trying to popoff
 
@@ -51,9 +52,10 @@
                 Dim result As String = http.GetUrl("http://localhost:8125/burst?requestType=clearUnconfirmedTransactions")
                 lblInfo.Text = "Popping off blocks"
                 result = http.GetUrl("http://localhost:8125/burst?requestType=popOff&height=&numBlocks=" & nrBlocks.Value.ToString)
+
+                wStep = 4
                 lblInfo.Text = "Stopping wallet."
                 frmMain.StopWallet()
-                wStep = 4
             Case 4
                 If frmMain.Running = False Then
                     If WasRunning Then


### PR DESCRIPTION
Replaced the hard coded API URLs for pop-off with same code used by 'goto-wallet' link.

Also found that pop-off crashes QBundle if run before wallet was started. (due to stopping a not running wallet)
And found by accident a rather uncommon bug: if `StartWallet` in `Case 1` is interrupted from a MessageBox (like 'another MariaDB process running' warning) the wait timer continues and tries to start wallet again. (looks funny with more and more spawning MessageBoxes :D) That's why the `wStep = 2` is now before `StartWallet`.